### PR TITLE
Fix Peformance Counters

### DIFF
--- a/src/timer/psl1ght/SDL_systimer.c
+++ b/src/timer/psl1ght/SDL_systimer.c
@@ -64,16 +64,28 @@ SDL_GetTicks64(void)
     return ticks;
 }
 
-Uint64
+Uint64 
 SDL_GetPerformanceCounter(void)
 {
-    return SDL_GetTicks();
+    if (!ticks_started) {
+        SDL_TicksInit();
+    }
+
+    struct timeval now;
+    Uint64 ticks;
+
+    gettimeofday(&now, NULL);
+    ticks = now.tv_sec;
+    ticks *= 1000000;
+    ticks += now.tv_usec;
+    
+    return ticks;
 }
 
-Uint64
+Uint64 
 SDL_GetPerformanceFrequency(void)
 {
-    return 1000;
+    return 1000000;
 }
 
 void


### PR DESCRIPTION
They were using 1000 as the frequency instead of 1000000 like most backends, this implementation is based on the one for the unix backend. Fixed a issue on an app I was porting with this fork, as it's performance stats were returning 0 instead of actual values due to the precision.
